### PR TITLE
docs: CLAUDE.mdに開発フローを追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,23 @@ describe("Instruction: 8XY4 (ADD VX, VY)", () => {
 - `StackPointer` に対する push/pop 境界チェック
 - `Screen` バッファを `Uint8Array` + 型付きアクセサで管理
 
+## 開発フロー
+
+- main ブランチへの直プッシュは禁止（ブランチ保護設定済み）
+- Phase ごとにブランチを作成し、PR を通じてマージする
+- PR 作成時、実装に着手する前にまず PR の description に実装計画を記述する
+  - 何を実装するか（スコープ）
+  - ファイル構成・型設計の方針
+  - テスト方針
+- 実装計画のレビュー後、コードを実装してプッシュする
+
+### ブランチ命名規則
+
+```
+phase/{phase番号}-{短い説明}
+例: phase/1-domain-types, phase/2-decoder
+```
+
 ## 技術スタック
 
 - **言語**: TypeScript (strict mode)


### PR DESCRIPTION
## Summary
- CLAUDE.md に開発フロー規約を追記
- main 直プッシュ禁止、Phase 毎の PR 作成、実装前に計画を記述するルールを定義
- ブランチ命名規則 (`phase/{番号}-{説明}`) を策定

🤖 Generated with [Claude Code](https://claude.com/claude-code)