### PR TITLE
Phase 3: CPU状態とメモリ

### DIFF
--- a/src/cpu/fetch.ts
+++ b/src/cpu/fetch.ts
@@ -1,0 +1,14 @@
+import type { Word } from "../domain/types.ts";
+import { mkAddress } from "../domain/types.ts";
+import type { Memory } from "../emulator/memory.ts";
+import type { CpuState } from "./state.ts";
+
+/**
+ * Fetch the next instruction word from memory at the current PC,
+ * then advance PC by 2.
+ */
+export function fetch(cpu: CpuState, memory: Memory): Word {
+  const word = memory.readWord(cpu.pc);
+  cpu.pc = mkAddress(cpu.pc + 2);
+  return word;
+}

--- a/src/cpu/state.ts
+++ b/src/cpu/state.ts
@@ -1,0 +1,60 @@
+import type { Address, Byte } from "../domain/types.ts";
+import { mkAddress, mkByte } from "../domain/types.ts";
+
+/** Number of general-purpose registers (V0–VF) */
+const REGISTER_COUNT = 16;
+
+/** Maximum stack depth */
+const STACK_SIZE = 16;
+
+/** Program start address */
+const PROGRAM_START: Address = mkAddress(0x200);
+
+/** CPU state for the CHIP-8 emulator */
+export interface CpuState {
+  /** General-purpose registers V0–VF (8-bit each) */
+  readonly v: Uint8Array;
+  /** Program counter (12-bit address) */
+  pc: Address;
+  /** Index register (12-bit address) */
+  i: Address;
+  /** Stack pointer */
+  sp: number;
+  /** Call stack (16 entries of 12-bit addresses) */
+  readonly stack: Uint16Array;
+  /** Delay timer (8-bit, decremented at 60Hz) */
+  dt: Byte;
+  /** Sound timer (8-bit, decremented at 60Hz) */
+  st: Byte;
+}
+
+/** Create a fresh CPU state with all values initialized */
+export function createInitialCpuState(): CpuState {
+  return {
+    v: new Uint8Array(REGISTER_COUNT),
+    pc: PROGRAM_START,
+    i: mkAddress(0),
+    sp: 0,
+    stack: new Uint16Array(STACK_SIZE),
+    dt: mkByte(0),
+    st: mkByte(0),
+  };
+}
+
+/** Push address onto the stack */
+export function stackPush(cpu: CpuState, address: Address): void {
+  if (cpu.sp >= STACK_SIZE) {
+    throw new Error("Stack overflow: stack is full");
+  }
+  cpu.stack[cpu.sp] = address;
+  cpu.sp++;
+}
+
+/** Pop address from the stack */
+export function stackPop(cpu: CpuState): Address {
+  if (cpu.sp <= 0) {
+    throw new Error("Stack underflow: stack is empty");
+  }
+  cpu.sp--;
+  return mkAddress(cpu.stack[cpu.sp]);
+}

--- a/src/emulator/memory.ts
+++ b/src/emulator/memory.ts
@@ -1,0 +1,56 @@
+import { FONT_DATA, FONT_START_ADDRESS } from "../domain/font.ts";
+import type { Address, Byte, Word } from "../domain/types.ts";
+import { mkByte, mkWord } from "../domain/types.ts";
+
+/** Total memory size: 4KB */
+const MEMORY_SIZE = 4096;
+
+/** ROM programs are loaded starting at this address */
+const ROM_START = 0x200;
+
+export class Memory {
+  private readonly ram: Uint8Array;
+
+  constructor() {
+    this.ram = new Uint8Array(MEMORY_SIZE);
+    this.loadFont();
+  }
+
+  /** Load built-in font sprites into memory at 0x000–0x04F */
+  private loadFont(): void {
+    for (let i = 0; i < FONT_DATA.length; i++) {
+      this.ram[FONT_START_ADDRESS + i] = FONT_DATA[i];
+    }
+  }
+
+  /** Read a single byte from memory */
+  readByte(address: Address): Byte {
+    return mkByte(this.ram[address]);
+  }
+
+  /** Write a single byte to memory */
+  writeByte(address: Address, value: Byte): void {
+    this.ram[address] = value;
+  }
+
+  /** Read a 16-bit word (big-endian) from memory */
+  readWord(address: Address): Word {
+    const high = this.ram[address];
+    const low = this.ram[address + 1];
+    return mkWord((high << 8) | low);
+  }
+
+  /** Load a ROM into memory starting at 0x200 */
+  loadRom(rom: Uint8Array): void {
+    if (rom.length > MEMORY_SIZE - ROM_START) {
+      throw new Error(`ROM too large: ${rom.length} bytes (max ${MEMORY_SIZE - ROM_START} bytes)`);
+    }
+    this.ram.set(rom, ROM_START);
+  }
+
+  /** Reset memory to initial state (clears RAM, reloads font) */
+  reset(): void {
+    this.ram.fill(0);
+    this.loadFont();
+  }
+}

--- a/tests/cpu/fetch.test.ts
+++ b/tests/cpu/fetch.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { fetch } from "../../src/cpu/fetch.ts";
+import { createInitialCpuState } from "../../src/cpu/state.ts";
+import { mkAddress, mkByte } from "../../src/domain/types.ts";
+import { Memory } from "../../src/emulator/memory.ts";
+
+describe("fetch", () => {
+  it("PC のアドレスから 16bit ワードを読み出す", () => {
+    const cpu = createInitialCpuState();
+    const mem = new Memory();
+    mem.writeByte(mkAddress(0x200), mkByte(0x12));
+    mem.writeByte(mkAddress(0x201), mkByte(0x34));
+    const word = fetch(cpu, mem);
+    assert.equal(word, 0x1234);
+  });
+
+  it("fetch 後に PC が 2 増加する", () => {
+    const cpu = createInitialCpuState();
+    const mem = new Memory();
+    mem.writeByte(mkAddress(0x200), mkByte(0x00));
+    mem.writeByte(mkAddress(0x201), mkByte(0xe0));
+    fetch(cpu, mem);
+    assert.equal(cpu.pc, 0x202);
+  });
+
+  it("連続 fetch で順次読み出せる", () => {
+    const cpu = createInitialCpuState();
+    const mem = new Memory();
+    mem.loadRom(new Uint8Array([0x00, 0xe0, 0x12, 0x34]));
+    assert.equal(fetch(cpu, mem), 0x00e0);
+    assert.equal(fetch(cpu, mem), 0x1234);
+    assert.equal(cpu.pc, 0x204);
+  });
+});

--- a/tests/cpu/state.test.ts
+++ b/tests/cpu/state.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createInitialCpuState, stackPop, stackPush } from "../../src/cpu/state.ts";
+import { mkAddress } from "../../src/domain/types.ts";
+
+describe("createInitialCpuState", () => {
+  it("PC の初期値は 0x200", () => {
+    const cpu = createInitialCpuState();
+    assert.equal(cpu.pc, 0x200);
+  });
+
+  it("レジスタ V0–VF が全て 0", () => {
+    const cpu = createInitialCpuState();
+    assert.equal(cpu.v.length, 16);
+    for (let i = 0; i < 16; i++) {
+      assert.equal(cpu.v[i], 0);
+    }
+  });
+
+  it("I レジスタの初期値は 0", () => {
+    const cpu = createInitialCpuState();
+    assert.equal(cpu.i, 0);
+  });
+
+  it("SP の初期値は 0", () => {
+    const cpu = createInitialCpuState();
+    assert.equal(cpu.sp, 0);
+  });
+
+  it("タイマー DT/ST の初期値は 0", () => {
+    const cpu = createInitialCpuState();
+    assert.equal(cpu.dt, 0);
+    assert.equal(cpu.st, 0);
+  });
+});
+
+describe("stackPush / stackPop", () => {
+  it("push した値を pop で取り出せる", () => {
+    const cpu = createInitialCpuState();
+    stackPush(cpu, mkAddress(0x300));
+    assert.equal(cpu.sp, 1);
+    const addr = stackPop(cpu);
+    assert.equal(addr, 0x300);
+    assert.equal(cpu.sp, 0);
+  });
+
+  it("LIFO 順序で取り出せる", () => {
+    const cpu = createInitialCpuState();
+    stackPush(cpu, mkAddress(0x100));
+    stackPush(cpu, mkAddress(0x200));
+    stackPush(cpu, mkAddress(0x300));
+    assert.equal(stackPop(cpu), 0x300);
+    assert.equal(stackPop(cpu), 0x200);
+    assert.equal(stackPop(cpu), 0x100);
+  });
+
+  it("16 エントリまで push できる", () => {
+    const cpu = createInitialCpuState();
+    for (let i = 0; i < 16; i++) {
+      stackPush(cpu, mkAddress(0x200 + i));
+    }
+    assert.equal(cpu.sp, 16);
+  });
+
+  it("17 回目の push でスタックオーバーフロー", () => {
+    const cpu = createInitialCpuState();
+    for (let i = 0; i < 16; i++) {
+      stackPush(cpu, mkAddress(0x200 + i));
+    }
+    assert.throws(() => stackPush(cpu, mkAddress(0x300)), Error);
+  });
+
+  it("空のスタックから pop でスタックアンダーフロー", () => {
+    const cpu = createInitialCpuState();
+    assert.throws(() => stackPop(cpu), Error);
+  });
+});

--- a/tests/emulator/memory.test.ts
+++ b/tests/emulator/memory.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { FONT_DATA } from "../../src/domain/font.ts";
+import { mkAddress, mkByte } from "../../src/domain/types.ts";
+import { Memory } from "../../src/emulator/memory.ts";
+
+describe("Memory", () => {
+  describe("初期化", () => {
+    it("フォントデータが 0x000–0x04F に配置されている", () => {
+      const mem = new Memory();
+      for (let i = 0; i < FONT_DATA.length; i++) {
+        assert.equal(mem.readByte(mkAddress(i)), FONT_DATA[i]);
+      }
+    });
+  });
+
+  describe("readByte / writeByte", () => {
+    it("書き込んだバイトを読み出せる", () => {
+      const mem = new Memory();
+      mem.writeByte(mkAddress(0x200), mkByte(0x42));
+      assert.equal(mem.readByte(mkAddress(0x200)), 0x42);
+    });
+
+    it("初期化されていないアドレスは 0 を返す", () => {
+      const mem = new Memory();
+      assert.equal(mem.readByte(mkAddress(0x500)), 0x00);
+    });
+  });
+
+  describe("readWord", () => {
+    it("ビッグエンディアンで 2 バイトを結合する", () => {
+      const mem = new Memory();
+      mem.writeByte(mkAddress(0x200), mkByte(0xab));
+      mem.writeByte(mkAddress(0x201), mkByte(0xcd));
+      assert.equal(mem.readWord(mkAddress(0x200)), 0xabcd);
+    });
+  });
+
+  describe("loadRom", () => {
+    it("ROM を 0x200 から配置する", () => {
+      const mem = new Memory();
+      const rom = new Uint8Array([0x12, 0x34, 0x56, 0x78]);
+      mem.loadRom(rom);
+      assert.equal(mem.readByte(mkAddress(0x200)), 0x12);
+      assert.equal(mem.readByte(mkAddress(0x201)), 0x34);
+      assert.equal(mem.readByte(mkAddress(0x202)), 0x56);
+      assert.equal(mem.readByte(mkAddress(0x203)), 0x78);
+    });
+
+    it("ROM がフォントデータを上書きしない", () => {
+      const mem = new Memory();
+      mem.loadRom(new Uint8Array([0xff]));
+      assert.equal(mem.readByte(mkAddress(0x000)), FONT_DATA[0]);
+    });
+
+    it("大きすぎる ROM はエラー", () => {
+      const mem = new Memory();
+      const tooLarge = new Uint8Array(4096 - 0x200 + 1);
+      assert.throws(() => mem.loadRom(tooLarge), Error);
+    });
+  });
+
+  describe("reset", () => {
+    it("RAM をクリアしてフォントを再配置する", () => {
+      const mem = new Memory();
+      mem.writeByte(mkAddress(0x300), mkByte(0xff));
+      mem.reset();
+      assert.equal(mem.readByte(mkAddress(0x300)), 0x00);
+      assert.equal(mem.readByte(mkAddress(0x000)), FONT_DATA[0]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `CpuState` インターフェース (V0–VF, PC, I, SP, スタック, DT, ST)
- `createInitialCpuState()` ファクトリ関数
- `stackPush` / `stackPop` (オーバーフロー/アンダーフロー検出)
- `Memory` クラス (4KB RAM, フォント初期配置, ROM ロード, リセット)
- `fetch()` 関数 (PC アドレスから Word 読み出し + PC += 2)

## ファイル構成
```
src/cpu/state.ts            # CpuState 型, 初期化, スタック操作
src/cpu/fetch.ts            # fetch 関数
src/emulator/memory.ts      # Memory クラス
tests/cpu/state.test.ts     # CPU 状態 + スタックのテスト
tests/cpu/fetch.test.ts     # fetch のテスト
tests/emulator/memory.test.ts # メモリのテスト
```

## Test plan
- [x] `pnpm test` — 94 テスト全 pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)