### PR TITLE
feat: E2Eテスト追加 (Playwright)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "test": "node --experimental-strip-types --test tests/**/*.test.ts",
+    "test:e2e": "playwright test",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "typecheck": "tsc --noEmit"
@@ -17,6 +18,7 @@
   "packageManager": "pnpm@10.11.1",
   "devDependencies": {
     "@biomejs/biome": "^2.4.6",
+    "@playwright/test": "^1.58.2",
     "@types/node": "^25.4.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.1"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+  webServer: {
+    command: "pnpm dev",
+    port: 5173,
+    reuseExistingServer: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.6
         version: 2.4.6
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@types/node':
         specifier: ^25.4.0
         version: 25.4.0
@@ -232,6 +235,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
@@ -377,6 +385,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -393,6 +406,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -574,6 +597,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -688,6 +715,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -696,6 +726,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.8:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+onlyBuiltDependencies: '["esbuild"]'

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,6 +90,7 @@ romSelect.addEventListener("change", async () => {
 resetBtn.addEventListener("click", () => {
   emulator.reset();
   running = false;
+  display.clear();
   display.render();
   statusEl.textContent = "Reset";
 });

--- a/tests/e2e/debug-panel.spec.ts
+++ b/tests/e2e/debug-panel.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+test("Debug パネルの表示/非表示が切り替わる", async ({ page }) => {
+  await page.goto("/");
+  const panel = page.locator("#debug-panel");
+
+  await expect(panel).not.toHaveClass(/visible/);
+
+  await page.click("#debug-toggle");
+  await expect(panel).toHaveClass(/visible/);
+  await expect(page.locator("#debug-toggle")).toHaveText("Hide Debug");
+
+  await page.click("#debug-toggle");
+  await expect(panel).not.toHaveClass(/visible/);
+  await expect(page.locator("#debug-toggle")).toHaveText("Debug");
+});
+
+test("ROM 実行中にレジスタ値が表示される", async ({ page }) => {
+  await page.goto("/");
+  await page.click("#debug-toggle");
+  await page.selectOption("#rom-select", "roms/PONG.ch8");
+  await page.waitForTimeout(300);
+
+  const regText = await page.locator("#debug-registers").textContent();
+  expect(regText).toContain("V0:");
+  expect(regText).toContain("VF:");
+
+  const metaText = await page.locator("#debug-meta").textContent();
+  expect(metaText).toContain("PC:");
+  expect(metaText).toContain("SP:");
+  expect(metaText).toContain("DT:");
+  expect(metaText).toContain("ST:");
+});

--- a/tests/e2e/keyboard-input.spec.ts
+++ b/tests/e2e/keyboard-input.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test("キーボード入力がエミュレータに反映される", async ({ page }) => {
+  await page.goto("/");
+  await page.selectOption("#rom-select", "roms/PONG.ch8");
+  await page.waitForTimeout(500);
+
+  // キー押下前の画面状態を取得
+  const before = await page.evaluate(() => {
+    const canvas = document.getElementById("display") as HTMLCanvasElement;
+    const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+    return Array.from(ctx.getImageData(0, 0, canvas.width, canvas.height).data);
+  });
+
+  // '1' キー (CHIP-8 の 0x1 に対応) を押し続ける
+  await page.keyboard.down("1");
+  await page.waitForTimeout(500);
+  await page.keyboard.up("1");
+  await page.waitForTimeout(200);
+
+  // キー押下後の画面状態を取得
+  const after = await page.evaluate(() => {
+    const canvas = document.getElementById("display") as HTMLCanvasElement;
+    const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+    return Array.from(ctx.getImageData(0, 0, canvas.width, canvas.height).data);
+  });
+
+  // 画面が変化していること（ゲームが進行した）
+  const changed = before.some((v, i) => v !== after[i]);
+  expect(changed).toBe(true);
+});

--- a/tests/e2e/maze-output.spec.ts
+++ b/tests/e2e/maze-output.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+test("MAZE ROM が画面を迷路パターンで埋める", async ({ page }) => {
+  await page.goto("/");
+  await page.selectOption("#rom-select", "roms/MAZE.ch8");
+  await expect(page.locator("#status")).toContainText("MAZE.ch8");
+
+  // MAZE は高速に画面を埋める — 2秒で十分
+  await page.waitForTimeout(2000);
+
+  const coverage = await page.evaluate(() => {
+    const canvas = document.getElementById("display") as HTMLCanvasElement;
+    const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+    const scale = 10;
+    const w = 64;
+    const h = 32;
+    let litPixels = 0;
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const px = x * scale + scale / 2;
+        const py = y * scale + scale / 2;
+        const [r, g, b] = ctx.getImageData(px, py, 1, 1).data;
+        if (r > 0 || g > 0 || b > 0) litPixels++;
+      }
+    }
+    return litPixels / (w * h);
+  });
+
+  // MAZE はランダムな斜線パターンで約50%のピクセルが点灯する
+  expect(coverage).toBeGreaterThan(0.2);
+  expect(coverage).toBeLessThan(0.7);
+});

--- a/tests/e2e/page-load.spec.ts
+++ b/tests/e2e/page-load.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@playwright/test";
+
+test("canvas が正しいサイズで表示される", async ({ page }) => {
+  await page.goto("/");
+  const canvas = page.locator("#display");
+  await expect(canvas).toBeVisible();
+  await expect(canvas).toHaveAttribute("width", "640");
+  await expect(canvas).toHaveAttribute("height", "320");
+});
+
+test("UI コントロールが表示される", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#rom-select")).toBeVisible();
+  await expect(page.locator("#reset-btn")).toBeVisible();
+  await expect(page.locator("#debug-toggle")).toBeVisible();
+  await expect(page.locator("#status")).toHaveText("No ROM loaded");
+});

--- a/tests/e2e/rom-loading.spec.ts
+++ b/tests/e2e/rom-loading.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+test("サンプル ROM を選択するとステータスが更新されピクセルが描画される", async ({ page }) => {
+  await page.goto("/");
+  await page.selectOption("#rom-select", "roms/PONG.ch8");
+
+  await expect(page.locator("#status")).toContainText("Loaded: PONG.ch8");
+
+  // エミュレーションが数フレーム進むのを待つ
+  await page.waitForTimeout(500);
+
+  const hasPixels = await page.evaluate(() => {
+    const canvas = document.getElementById("display") as HTMLCanvasElement;
+    const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i] > 0 || data[i + 1] > 0 || data[i + 2] > 0) return true;
+    }
+    return false;
+  });
+  expect(hasPixels).toBe(true);
+});
+
+test("Reset で画面がクリアされステータスが更新される", async ({ page }) => {
+  await page.goto("/");
+  await page.selectOption("#rom-select", "roms/PONG.ch8");
+  await expect(page.locator("#status")).toContainText("Loaded");
+  await page.waitForTimeout(300);
+
+  await page.click("#reset-btn");
+  await expect(page.locator("#status")).toHaveText("Reset");
+
+  const allBlack = await page.evaluate(() => {
+    const canvas = document.getElementById("display") as HTMLCanvasElement;
+    const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i] > 0 || data[i + 1] > 0 || data[i + 2] > 0) return false;
+    }
+    return true;
+  });
+  expect(allBlack).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Playwright による E2E テスト 8 件を追加し、ブラウザ上でのエミュレータ動作を自動検証
- リセット時に `display.clear()` が呼ばれていなかったバグを修正
- テスト対象: ページ読み込み、ROM ロード/リセット、MAZE 出力、キーボード入力、デバッグパネル

## Test plan
- [x] `pnpm test` — 全 149 ユニットテスト pass
- [x] `pnpm test:e2e` — 全 8 E2E テスト pass
- [x] `pnpm lint` — warnings なし
- [x] `pnpm typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)