### PR TITLE
feat: support atomic draw batching and key edges

### DIFF
--- a/src/cpu/decode.ts
+++ b/src/cpu/decode.ts
@@ -20,6 +20,10 @@ export function decode(opcode: Word): Instruction {
           return { tag: "NOP" };
         case 0x00e0:
           return { tag: "CLS" };
+        case 0x00f0:
+          return { tag: "BEGIN_DRAW_BATCH" };
+        case 0x00f1:
+          return { tag: "END_DRAW_BATCH" };
         case 0x00ee:
           return { tag: "RET" };
         default:
@@ -76,6 +80,8 @@ export function decode(opcode: Word): Instruction {
       switch (opcode & 0x00ff) {
         case 0x9e:
           return { tag: "SKP", vx: x };
+        case 0x9f:
+          return { tag: "JKP", vx: x };
         case 0xa1:
           return { tag: "SKNP", vx: x };
         default:

--- a/src/cpu/execute.ts
+++ b/src/cpu/execute.ts
@@ -24,6 +24,14 @@ export function execute(
       peripherals.display.clear();
       break;
 
+    case "BEGIN_DRAW_BATCH":
+      peripherals.display.beginDrawBatch();
+      break;
+
+    case "END_DRAW_BATCH":
+      peripherals.display.endDrawBatch();
+      break;
+
     case "RET":
       cpu.pc = stackPop(cpu);
       break;
@@ -161,6 +169,12 @@ export function execute(
 
     case "SKP":
       if (peripherals.keyboard.isKeyPressed(mkByte(cpu.v[instruction.vx]))) {
+        cpu.pc = mkAddress(cpu.pc + 2);
+      }
+      break;
+
+    case "JKP":
+      if (peripherals.keyboard.isKeyJustPressed(mkByte(cpu.v[instruction.vx]))) {
         cpu.pc = mkAddress(cpu.pc + 2);
       }
       break;

--- a/src/domain/instruction.ts
+++ b/src/domain/instruction.ts
@@ -4,6 +4,8 @@ import type { Address, Byte, Nibble, RegisterIndex } from "./types.ts";
 export type Instruction =
   | { readonly tag: "NOP" }
   | { readonly tag: "CLS" }
+  | { readonly tag: "BEGIN_DRAW_BATCH" }
+  | { readonly tag: "END_DRAW_BATCH" }
   | { readonly tag: "RET" }
   | { readonly tag: "JP"; readonly address: Address }
   | { readonly tag: "CALL"; readonly address: Address }
@@ -32,6 +34,7 @@ export type Instruction =
       readonly nibble: Nibble;
     }
   | { readonly tag: "SKP"; readonly vx: RegisterIndex }
+  | { readonly tag: "JKP"; readonly vx: RegisterIndex }
   | { readonly tag: "SKNP"; readonly vx: RegisterIndex }
   | { readonly tag: "LD_VX_DT"; readonly vx: RegisterIndex }
   | { readonly tag: "LD_VX_K"; readonly vx: RegisterIndex }

--- a/src/frontend/canvas-display.ts
+++ b/src/frontend/canvas-display.ts
@@ -8,6 +8,8 @@ const COLOR_OFF = "#000000";
 export class CanvasDisplay implements Display {
   private readonly ctx: CanvasRenderingContext2D;
   private readonly pixels: boolean[][];
+  private readonly committedPixels: boolean[][];
+  private batchDepth = 0;
 
   constructor(canvas: HTMLCanvasElement) {
     canvas.width = DISPLAY_WIDTH * SCALE;
@@ -18,11 +20,40 @@ export class CanvasDisplay implements Display {
     this.pixels = Array.from({ length: DISPLAY_HEIGHT }, () =>
       Array<boolean>(DISPLAY_WIDTH).fill(false),
     );
+    this.committedPixels = Array.from({ length: DISPLAY_HEIGHT }, () =>
+      Array<boolean>(DISPLAY_WIDTH).fill(false),
+    );
     this.render();
   }
 
   clear(): void {
     for (const row of this.pixels) row.fill(false);
+    if (this.batchDepth === 0) {
+      for (const row of this.committedPixels) row.fill(false);
+    }
+  }
+
+  beginDrawBatch(): void {
+    if (this.batchDepth === 0) {
+      for (let y = 0; y < DISPLAY_HEIGHT; y++) {
+        for (let x = 0; x < DISPLAY_WIDTH; x++) {
+          this.pixels[y][x] = this.committedPixels[y][x];
+        }
+      }
+    }
+    this.batchDepth += 1;
+  }
+
+  endDrawBatch(): void {
+    if (this.batchDepth === 0) return;
+    this.batchDepth -= 1;
+    if (this.batchDepth === 0) {
+      for (let y = 0; y < DISPLAY_HEIGHT; y++) {
+        for (let x = 0; x < DISPLAY_WIDTH; x++) {
+          this.committedPixels[y][x] = this.pixels[y][x];
+        }
+      }
+    }
   }
 
   getPixel(x: number, y: number): boolean {
@@ -32,14 +63,18 @@ export class CanvasDisplay implements Display {
   xorPixel(x: number, y: number): boolean {
     const wasOn = this.pixels[y][x];
     this.pixels[y][x] = !wasOn;
+    if (this.batchDepth === 0) {
+      this.committedPixels[y][x] = this.pixels[y][x];
+    }
     return wasOn;
   }
 
   /** Render the pixel buffer to the canvas */
   render(): void {
+    const source = this.batchDepth > 0 ? this.committedPixels : this.pixels;
     for (let y = 0; y < DISPLAY_HEIGHT; y++) {
       for (let x = 0; x < DISPLAY_WIDTH; x++) {
-        this.ctx.fillStyle = this.pixels[y][x] ? COLOR_ON : COLOR_OFF;
+        this.ctx.fillStyle = source[y][x] ? COLOR_ON : COLOR_OFF;
         this.ctx.fillRect(x * SCALE, y * SCALE, SCALE, SCALE);
       }
     }

--- a/src/frontend/keyboard-input.ts
+++ b/src/frontend/keyboard-input.ts
@@ -30,12 +30,16 @@ const KEY_MAP: Record<string, number> = {
 
 export class KeyboardInput implements Keyboard {
   private readonly pressed = new Set<number>();
+  private readonly justPressed = new Set<number>();
   private lastKeyPressed: number | null = null;
 
   constructor() {
     document.addEventListener("keydown", (e) => {
       const key = KEY_MAP[e.key.toLowerCase()];
       if (key !== undefined) {
+        if (!this.pressed.has(key)) {
+          this.justPressed.add(key);
+        }
         this.pressed.add(key);
         this.lastKeyPressed = key;
       }
@@ -51,6 +55,10 @@ export class KeyboardInput implements Keyboard {
 
   isKeyPressed(key: Byte): boolean {
     return this.pressed.has(key);
+  }
+
+  isKeyJustPressed(key: Byte): boolean {
+    return this.justPressed.delete(key);
   }
 
   getKeyPress(): Byte | null {

--- a/src/peripherals/interfaces.ts
+++ b/src/peripherals/interfaces.ts
@@ -4,6 +4,10 @@ import type { Byte } from "../domain/types.ts";
 export interface Display {
   /** Clear all pixels */
   clear(): void;
+  /** Begin an atomic draw batch. Intermediate states stay hidden until committed. */
+  beginDrawBatch(): void;
+  /** Commit the current atomic draw batch. */
+  endDrawBatch(): void;
   /** Get pixel at (x, y). Returns true if pixel is on. */
   getPixel(x: number, y: number): boolean;
   /** Set pixel at (x, y) via XOR. Returns true if pixel was turned off (collision). */
@@ -14,6 +18,8 @@ export interface Display {
 export interface Keyboard {
   /** Returns true if the key is currently pressed */
   isKeyPressed(key: Byte): boolean;
+  /** Returns true once when the key transitions from up to down */
+  isKeyJustPressed(key: Byte): boolean;
   /** Returns the key that was pressed (blocking in real impl, returns null if none) */
   getKeyPress(): Byte | null;
 }

--- a/tests/cpu/decode.test.ts
+++ b/tests/cpu/decode.test.ts
@@ -12,6 +12,14 @@ describe("decode: 0x0NNN 系", () => {
     assert.deepEqual(decode(mkWord(0x00e0)), { tag: "CLS" });
   });
 
+  it("0x00F0 → BEGIN_DRAW_BATCH", () => {
+    assert.deepEqual(decode(mkWord(0x00f0)), { tag: "BEGIN_DRAW_BATCH" });
+  });
+
+  it("0x00F1 → END_DRAW_BATCH", () => {
+    assert.deepEqual(decode(mkWord(0x00f1)), { tag: "END_DRAW_BATCH" });
+  });
+
   it("0x00EE → RET", () => {
     assert.deepEqual(decode(mkWord(0x00ee)), { tag: "RET" });
   });
@@ -142,6 +150,10 @@ describe("decode: 0xDXYN — DRW Vx, Vy, nibble", () => {
 describe("decode: 0xEXNN 系 (キー入力)", () => {
   it("0xE19E → SKP V1", () => {
     assert.deepEqual(decode(mkWord(0xe19e)), { tag: "SKP", vx: 0x1 });
+  });
+
+  it("0xE19F → JKP V1", () => {
+    assert.deepEqual(decode(mkWord(0xe19f)), { tag: "JKP", vx: 0x1 });
   });
 
   it("0xE2A1 → SKNP V2", () => {

--- a/tests/cpu/execute.test.ts
+++ b/tests/cpu/execute.test.ts
@@ -15,6 +15,8 @@ function createMockDisplay(): Display & { pixels: boolean[][] } {
     clear() {
       for (const row of pixels) row.fill(false);
     },
+    beginDrawBatch() {},
+    endDrawBatch() {},
     getPixel(x: number, y: number) {
       return pixels[y][x];
     },
@@ -29,10 +31,14 @@ function createMockDisplay(): Display & { pixels: boolean[][] } {
 function createMockKeyboard(
   pressedKeys: Set<number> = new Set(),
   pendingKey: number | null = null,
+  justPressedKeys: Set<number> = new Set(),
 ): Keyboard {
   return {
     isKeyPressed(key) {
       return pressedKeys.has(key);
+    },
+    isKeyJustPressed(key) {
+      return justPressedKeys.delete(key);
     },
     getKeyPress() {
       return pendingKey !== null ? mkByte(pendingKey) : null;
@@ -76,6 +82,33 @@ describe("execute: CLS", () => {
     const p = createPeripherals(display);
     exec({ tag: "CLS" }, p);
     assert.equal(display.pixels[0][0], false);
+  });
+});
+
+describe("execute: custom draw batch opcodes", () => {
+  it("BEGIN_DRAW_BATCH / END_DRAW_BATCH を呼び出す", () => {
+    let begins = 0;
+    let ends = 0;
+    const display: Display = {
+      clear() {},
+      beginDrawBatch() {
+        begins += 1;
+      },
+      endDrawBatch() {
+        ends += 1;
+      },
+      getPixel() {
+        return false;
+      },
+      xorPixel() {
+        return false;
+      },
+    };
+    const p = createPeripherals(display);
+    exec({ tag: "BEGIN_DRAW_BATCH" }, p);
+    exec({ tag: "END_DRAW_BATCH" }, p);
+    assert.equal(begins, 1);
+    assert.equal(ends, 1);
   });
 });
 
@@ -560,6 +593,30 @@ describe("execute: SKP (EX9E)", () => {
     cpu.v[0] = 5;
     const memory = new Memory();
     execute(cpu, memory, { tag: "SKP", vx: mkRegisterIndex(0) }, createPeripherals());
+    assert.equal(cpu.pc, 0x200);
+  });
+});
+
+describe("execute: JKP (EX9F)", () => {
+  it("just pressed なら PC += 2", () => {
+    const cpu = createInitialCpuState();
+    cpu.v[0] = 5;
+    const memory = new Memory();
+    const keyboard = createMockKeyboard(new Set(), null, new Set([5]));
+    execute(
+      cpu,
+      memory,
+      { tag: "JKP", vx: mkRegisterIndex(0) },
+      createPeripherals(undefined, keyboard),
+    );
+    assert.equal(cpu.pc, 0x202);
+  });
+
+  it("just pressed でなければ PC 変更なし", () => {
+    const cpu = createInitialCpuState();
+    cpu.v[0] = 5;
+    const memory = new Memory();
+    execute(cpu, memory, { tag: "JKP", vx: mkRegisterIndex(0) }, createPeripherals());
     assert.equal(cpu.pc, 0x200);
   });
 });

--- a/tests/emulator/emulator.test.ts
+++ b/tests/emulator/emulator.test.ts
@@ -10,6 +10,8 @@ function createMockDisplay(): Display & { pixels: boolean[][] } {
     clear() {
       for (const row of pixels) row.fill(false);
     },
+    beginDrawBatch() {},
+    endDrawBatch() {},
     getPixel(x: number, y: number) {
       return pixels[y][x];
     },
@@ -27,6 +29,9 @@ function createMockPeripherals(): Peripherals & { display: ReturnType<typeof cre
     display,
     keyboard: {
       isKeyPressed() {
+        return false;
+      },
+      isKeyJustPressed() {
         return false;
       },
       getKeyPress() {


### PR DESCRIPTION
## Summary
- add runtime support for atomic draw batch opcodes and one-shot key edge detection
- hide intermediate draw/undo states in `CanvasDisplay` during batched rendering
- extend decode/execute tests and emulator test doubles

## Verification
- pnpm test
- pnpm build

## Dependency
- depends on `okayus/chip8-lang#52`